### PR TITLE
remove call to replace() that has no effect

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -53,7 +53,7 @@ exports.copy = function (source, target, options) {
     var sourcePath = Path.resolve(root, source);
     var targetPath = Path.resolve(projectRoot, target || source);
 
-    if (!(new RegExp('^' + projectRoot.replace(/\//g, '\/').replace(/\\/g, '\\\\') + internals.pathSep + '.*$')).test(targetPath)) {
+    if (!(new RegExp('^' + projectRoot.replace(/\\/g, '\\\\') + internals.pathSep + '.*$')).test(targetPath)) {
         throw new Error('Destination must be within project root');
     }
 


### PR DESCRIPTION
`'/'.replace(/\//g, '\/') === '/'`

That's basically a no-op.
