### PR TITLE
Simplify check to see if destination path is outwith project root

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -53,7 +53,7 @@ exports.copy = function (source, target, options) {
     var sourcePath = Path.resolve(root, source);
     var targetPath = Path.resolve(projectRoot, target || source);
 
-    if (!(new RegExp('^' + projectRoot.replace(/\//g, '\/').replace(/\\/g, '\\\\') + internals.pathSep + '.*$')).test(targetPath)) {
+    if (targetPath.indexOf(projectRoot) !== 0) {
         throw new Error('Destination must be within project root');
     }
 


### PR DESCRIPTION
fixes #11

Any reason we can't just do this? The complexity of the regex suggests to me I may be missing something, but tests pass, and regexes have a habit of getting complex just because.
