### PR TITLE
refactor: path module already has your back on the whole separator thing

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -33,10 +33,6 @@ internals.mkdir = function (path) {
     }
 };
 
-
-internals.pathSep = process.platform === 'win32' ? '\\\\' : '\/';
-
-
 // Expands source and target to absolute paths, then calls internals.copy
 exports.copy = function (source, target, options) {
 
@@ -53,7 +49,7 @@ exports.copy = function (source, target, options) {
     var sourcePath = Path.resolve(root, source);
     var targetPath = Path.resolve(projectRoot, target || source);
 
-    if (!(new RegExp('^' + projectRoot.replace(/\//g, '\/').replace(/\\/g, '\\\\') + internals.pathSep + '.*$')).test(targetPath)) {
+    if (!(new RegExp('^' + projectRoot.replace(/\//g, '\/').replace(/\\/g, '\\\\') + Path.sep + '.*$')).test(targetPath)) {
         throw new Error('Destination must be within project root');
     }
 


### PR DESCRIPTION
No need to calculate the path separator. The path module already does that.
