### PR TITLE
Fix validate script not spawning tasks correctly

### DIFF
--- a/bin/validate
+++ b/bin/validate
@@ -73,7 +73,7 @@ internals.runCmd = function (projectRoot, env, name, script, done) {
 
     process.stdout.write('running ' + name + ': ' + pad);
     var cmd = 'sh';
-    var args = ['-c'].concat(script.split(' '));
+    var args = ['-c', script];
 
     logFile.on('open', function () {
 


### PR DESCRIPTION
We are spawning the tasks with sh -c which expects a string of the full
command. The old implementation was splitting the command into an args
array, meaning that sh -c was only looking at the first argument. For,
e.g. jshint, this means that instead of "jshint ." it was running
"jshint". Which is basically a no-op that will always pass.

Fixes #17
