### PR TITLE
Make it work in Windows

### DIFF
--- a/bin/validate
+++ b/bin/validate
@@ -125,6 +125,13 @@ internals.exit = function (code, callback) {
     });
 
     tryToExit();
+    
+    // In Windows, when run as a Node.js child process, a script utilizing
+    // this library might just exit with a 0 exit code, regardless. This code,
+    // despite the fact that it looks a bit crazy, appears to fix that
+    process.on('exit', function() {
+        process.exit(exitCode);
+    });
 }
 
 


### PR DESCRIPTION
In Windows,
I use precommit-hook
it passed all JSHint, but git didn't commit after checking.
I found this code in https://github.com/cowboy/node-exit/blob/master/lib/exit.js

It works after I added this lines.
