### PR TITLE
findGitRoot throws an error instead of returning undefined

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -134,6 +134,9 @@ exports.findGitRoot = function (start) {
     else if (Path.dirname(start) !== start) {
         root = exports.findGitRoot(Path.dirname(start));
     }
+    else {
+	throw new Error('Unable to find a .git folder for this project');
+    }
 
     return root;
 };

--- a/test/utils.js
+++ b/test/utils.js
@@ -157,9 +157,12 @@ describe('findGitRoot()', function () {
         done();
     });
 
-    it('returns undefined when no git root exists', function (done) {
+    it('can return an error when no git root exists', function (done) {
 
-        expect(Utils.findGitRoot(Path.resolve(__dirname, '..', '..'))).to.be.undefined();
+        expect(function () {
+
+            Utils.findGitRoot(Path.resolve(__dirname, '..', '..'));
+	}).to.throw('Unable to find a .git folder for this project');
         done();
     });
 });


### PR DESCRIPTION
findGitRoot throws an error instead of returning undefined

Fix #26