### PR TITLE
Remove .validate.json

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -1,14 +1,3 @@
-var Fs = require('fs');
-var Path = require('path');
 var Utils = require('../lib/utils');
 
-var projectRoot;
-try {
-    projectRoot = Utils.findProjectRoot();
-}
-catch (e) {
-    process.exit();
-}
-
-var project = JSON.parse(Fs.readFileSync(Path.join(projectRoot, 'package.json'), 'utf8'));
 Utils.installHooks(['pre-commit', 'pre-push']);

--- a/bin/install.js
+++ b/bin/install.js
@@ -1,0 +1,2 @@
+console.log(process.env);
+console.log(__dirname);

--- a/bin/install.js
+++ b/bin/install.js
@@ -11,5 +11,4 @@ catch (e) {
 }
 
 var project = JSON.parse(Fs.readFileSync(Path.join(projectRoot, 'package.json'), 'utf8'));
-Utils.installHook('pre-commit');
-Utils.installHook('pre-push');
+Utils.installHooks(['pre-commit', 'pre-push']);

--- a/bin/install.js
+++ b/bin/install.js
@@ -1,2 +1,15 @@
-console.log(process.env);
-console.log(__dirname);
+var Fs = require('fs');
+var Path = require('path');
+var Utils = require('../lib/utils');
+
+var projectRoot;
+try {
+    projectRoot = Utils.findProjectRoot();
+}
+catch (e) {
+    process.exit();
+}
+
+var project = JSON.parse(Fs.readFileSync(Path.join(projectRoot, 'package.json'), 'utf8'));
+Utils.installHook('pre-commit');
+Utils.installHook('pre-push');

--- a/bin/validate.sh
+++ b/bin/validate.sh
@@ -326,7 +326,7 @@ run_hook() {
     fi
 
     pushd "$git_root" >/dev/null
-    local projects=$(find . -maxdepth 3 -name package.json -print | grep -v node_modules | sed s/\.//)
+    local projects=$(find . -not -iwholename '*node_modules*' -not -iwholename '*bower_components*' -maxdepth 3 -name package.json -print | sed s/\.//)
     popd >/dev/null
 
     local result=0

--- a/bin/validate.sh
+++ b/bin/validate.sh
@@ -219,16 +219,12 @@ find_script() {
 
 # Run the named script, searches both package.json and .validate.json
 run_script() {
-    local defaults=$1
-    local json=$2
-    local name=$3
+    local json=$1
+    local name=$2
 
     echo -n "running $name..."
 
     local script=$(find_script "$json" "$name")
-    if [[ "$script" == "" ]] && [[ "$defaults" != "" ]]; then
-        script=$(find_script "$defaults" "$name")
-    fi
 
     if [[ "$script" == "" ]]; then
         echo "not found!"
@@ -290,15 +286,6 @@ check_project() {
         exit 1
     fi
 
-    local defaults=""
-    if [[ -f "$dir/.validate.json" ]]; then
-        defaults=$(cat "$dir/.validate.json" | parse_json)
-        if [[ $? -ne 0 ]]; then
-            echo "failed parsing $dir/.validate.json.. exiting"
-            exit 1
-        fi
-    fi
-
     pushd "$dir" >/dev/null
     local branch; branch=$(git rev-parse --abbrev-ref HEAD 2>&1)
     if [[ $? -ne 0 ]]; then
@@ -307,9 +294,6 @@ check_project() {
     fi
 
     local commands=$(find_commands "$json" "$branch")
-    if [[ "$commands" == "" ]] && [[ "$defaults" != "" ]]; then
-        commands=$(find_commands "$defaults" "$branch")
-    fi
 
     if [[ "$commands" == "" ]]; then
         popd >/dev/null
@@ -317,7 +301,7 @@ check_project() {
     fi
 
     for cmd in $commands; do
-        run_script "$defaults" "$json" "$cmd" "$branch"
+        run_script "$json" "$cmd" "$branch"
         local result=$?
         [[ $result -ne 0 ]] && break
     done

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -146,7 +146,7 @@ exports.findGitRoot = function (start) {
         root = exports.findGitRoot(Path.dirname(start));
     }
     else {
-        return internals.throwWarn('Unable to find a .git folder for this project');
+        return internals.throwWarn('Unable to find a .git directory for this project');
     }
     /* $lab:coverage:on$ */
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -135,7 +135,7 @@ exports.findGitRoot = function (start) {
         root = exports.findGitRoot(Path.dirname(start));
     }
     else {
-	throw new Error('Unable to find a .git folder for this project');
+        throw new Error('Unable to find a .git folder for this project');
     }
 
     return root;
@@ -205,26 +205,42 @@ exports.findProjects = function (start, depth) {
     return projects;
 };
 
-// Install the git hooks as specified by `hooks`. Should be an array of
-// strings, like ['pre-commit']. Will automatically turn a single argument into
-// an array for simplicity (e.g. Validate.installHooks('pre-commit') works fine).
-exports.installHooks = function (hooks, root) {
-
-    if (!Array.isArray(hooks)) {
-        hooks = [hooks];
-    }
+// Install the git hook as specified by `hook`, with an optional default configuration.
+// For example, Validate.installHook('pre-commit', ['test']);
+exports.installHook = function (hook, defaults, root) {
 
     var gitRoot = exports.findGitRoot(root);
 
-    for (var i = 0, l = hooks.length; i < l; ++i) {
-        var hook = hooks[i];
-        var dest = Path.join(gitRoot, '.git', 'hooks', hook);
-        var source = Path.resolve(__dirname, '..', 'bin', 'validate.sh');
+    var dest = Path.join(gitRoot, '.git', 'hooks', hook);
+    var source = Path.resolve(__dirname, '..', 'bin', 'validate.sh');
 
-        if (Fs.existsSync(dest)) {
-            Fs.renameSync(dest, dest + '.backup');
+    if (Fs.existsSync(dest)) {
+        Fs.renameSync(dest, dest + '.backup');
+    }
+
+    Fs.writeFileSync(dest, Fs.readFileSync(source), { mode: 511 });
+
+    if (defaults) {
+        var packagePath = Path.join(exports.findProjectRoot(root), 'package.json');
+        var package = JSON.parse(Fs.readFileSync(packagePath, { encoding: 'utf8' }));
+        if (!package.hasOwnProperty(hook)) {
+            package[hook] = Array.isArray(defaults) ? defaults : [defaults];
+            Fs.writeFileSync(packagePath, JSON.stringify(package, null, 2), { encoding: 'utf8' });
         }
+    }
+};
 
-        Fs.writeFileSync(dest, Fs.readFileSync(source), { mode: 511 });
+// Configure a default script by name and content
+// For example, Validate.installScript('test', 'lab -a code -L');
+exports.installScript = function (name, script, root) {
+
+    var packagePath = Path.join(exports.findProjectRoot(root), 'package.json');
+    var package = JSON.parse(Fs.readFileSync(packagePath, { encoding: 'utf8' }));
+    if (!package.hasOwnProperty('scripts') ||
+        !package.scripts.hasOwnProperty(name)) {
+
+        package.scripts = package.scripts || {};
+        package.scripts[name] = script;
+        Fs.writeFileSync(packagePath, JSON.stringify(package, null, 2), { encoding: 'utf8' });
     }
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -207,18 +207,23 @@ exports.findProjects = function (start, depth) {
 
 // Install the git hook as specified by `hook`.
 // For example, Validate.installHook('pre-commit');
-exports.installHook = function (hook, root) {
+exports.installHooks = function (hooks, root) {
 
+    hooks = Array.isArray(hooks) ? hooks : [hooks];
     var gitRoot = exports.findGitRoot(root);
-
-    var dest = Path.join(gitRoot, '.git', 'hooks', hook);
+    var hookRoot = Path.join(gitRoot, '.git', 'hooks');
     var source = Path.resolve(__dirname, '..', 'bin', 'validate.sh');
 
-    if (Fs.existsSync(dest)) {
-        Fs.renameSync(dest, dest + '.backup');
-    }
+    for (var i = 0, il = hooks.length; i < il; ++i) {
+        var hook = hooks[i];
+        var dest = Path.join(hookRoot, hook);
 
-    Fs.writeFileSync(dest, Fs.readFileSync(source), { mode: 511 });
+        if (Fs.existsSync(dest)) {
+            Fs.renameSync(dest, dest + '.backup');
+        }
+
+        Fs.writeFileSync(dest, Fs.readFileSync(source), { mode: 511 });
+    }
 };
 
 // Provide a default configuration for a git hook as specified by `hook`.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -205,9 +205,9 @@ exports.findProjects = function (start, depth) {
     return projects;
 };
 
-// Install the git hook as specified by `hook`, with an optional default configuration.
-// For example, Validate.installHook('pre-commit', ['test']);
-exports.installHook = function (hook, defaults, root) {
+// Install the git hook as specified by `hook`.
+// For example, Validate.installHook('pre-commit');
+exports.installHook = function (hook, root) {
 
     var gitRoot = exports.findGitRoot(root);
 
@@ -219,14 +219,17 @@ exports.installHook = function (hook, defaults, root) {
     }
 
     Fs.writeFileSync(dest, Fs.readFileSync(source), { mode: 511 });
+};
 
-    if (defaults) {
-        var packagePath = Path.join(exports.findProjectRoot(root), 'package.json');
-        var package = JSON.parse(Fs.readFileSync(packagePath, { encoding: 'utf8' }));
-        if (!package.hasOwnProperty(hook)) {
-            package[hook] = Array.isArray(defaults) ? defaults : [defaults];
-            Fs.writeFileSync(packagePath, JSON.stringify(package, null, 2), { encoding: 'utf8' });
-        }
+// Provide a default configuration for a git hook as specified by `hook`.
+// For example, Validate.configureHook('pre-commit', ['test', 'lint']);
+exports.configureHook = function (hook, defaults, root) {
+
+    var packagePath = Path.join(exports.findProjectRoot(root), 'package.json');
+    var package = JSON.parse(Fs.readFileSync(packagePath, { encoding: 'utf8' }));
+    if (!package.hasOwnProperty(hook)) {
+        package[hook] = Array.isArray(defaults) ? defaults : [defaults];
+        Fs.writeFileSync(packagePath, JSON.stringify(package, null, 2), { encoding: 'utf8' });
     }
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,11 +4,14 @@ var Path = require('path');
 var internals = {};
 
 
+/* $lab:coverage:off$ */
+// Coverage disabled for this method because we use a child process to test it due to the process.exit() call
 internals.throwWarn = function (warning) {
 
     console.error('WARNING: ' + warning + ', installation aborted.');
     process.exit(0);
 };
+/* $lab:coverage:on$ */
 
 // Find the topmost parent of the given module.
 internals.findParent = function (mod) {
@@ -137,12 +140,15 @@ exports.findGitRoot = function (start) {
     if (exports.isDir(Path.join(start, '.git'))) {
         root = start;
     }
+    /* $lab:coverage:off$ */
+    // Coverage disabled here due to false positive on else if, since we have to trap the throwWarn method
     else if (Path.dirname(start) !== start) {
         root = exports.findGitRoot(Path.dirname(start));
     }
     else {
-	return internals.throwWarn('Unable to find a .git folder for this project');
+        return internals.throwWarn('Unable to find a .git folder for this project');
     }
+    /* $lab:coverage:on$ */
 
     return root;
 };
@@ -159,9 +165,12 @@ exports.findProjectRoot = function (start) {
     start = start || Path.dirname(internals.findParent(module).filename);
     var position = start.indexOf('node_modules');
     var root = start.slice(0, position === -1 ? undefined : position - Path.sep.length);
+    /* $lab:coverage:off$ */
+    // Coverage disabled here due to having to trap the throwWarn method
     if (root === Path.resolve(root, '..')) {
         return internals.throwWarn('Unable to find a package.json for this project');
     }
+    /* $lab:coverage:on$ */
 
     while (!Fs.existsSync(Path.join(root, 'package.json'))) {
         root = exports.findProjectRoot(Path.dirname(root));

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "the extensible core of precommit-hook",
   "main": "index.js",
   "scripts": {
-    "test": "lab -L -a code -t 100"
+    "test": "lab -L -a code -t 100",
+    "install": "node bin/install"
   },
   "repository": {
     "type": "git",

--- a/test/utils.js
+++ b/test/utils.js
@@ -224,24 +224,32 @@ describe('installHook()', function () {
 
     it('can install a hook', function (done) {
 
-        Utils.installHook('pre-commit', null, Path.join(internals.fixturePath, 'project2'));
+        Utils.installHook('pre-commit', Path.join(internals.fixturePath, 'project2'));
         expect(Fs.existsSync(Path.join(internals.fixturePath, 'project2', '.git', 'hooks', 'pre-commit'))).to.be.true();
         done();
     });
 
     it('backs up an existing hook when installing', function (done) {
 
-        Utils.installHook('pre-commit', null, Path.join(internals.fixturePath, 'project2'));
+        Utils.installHook('pre-commit', Path.join(internals.fixturePath, 'project2'));
         expect(Fs.existsSync(Path.join(internals.fixturePath, 'project2', '.git', 'hooks', 'pre-commit'))).to.be.true();
-        Utils.installHook('pre-commit', null, Path.join(internals.fixturePath, 'project2'));
+        Utils.installHook('pre-commit', Path.join(internals.fixturePath, 'project2'));
         expect(Fs.existsSync(Path.join(internals.fixturePath, 'project2', '.git', 'hooks', 'pre-commit'))).to.be.true();
         expect(Fs.existsSync(Path.join(internals.fixturePath, 'project2', '.git', 'hooks', 'pre-commit.backup'))).to.be.true();
         done();
     });
 
+    afterEach(internals.cleanupFixture);
+});
+
+describe('configureHook()', function () {
+
+    beforeEach(internals.createFixture);
+
     it('can install a hook with defaults as a string', function (done) {
 
-        Utils.installHook('pre-commit', 'test', Path.join(internals.fixturePath, 'project2'));
+        Utils.installHook('pre-commit', Path.join(internals.fixturePath, 'project2'));
+        Utils.configureHook('pre-commit', 'test', Path.join(internals.fixturePath, 'project2'));
         expect(Fs.existsSync(Path.join(internals.fixturePath, 'project2', '.git', 'hooks', 'pre-commit'))).to.be.true();
         var fixturePackage = JSON.parse(Fs.readFileSync(Path.join(internals.fixturePath, 'project2', 'package.json'), { encoding: 'utf8' }));
         expect(fixturePackage['pre-commit']).to.deep.equal(['test']);
@@ -250,7 +258,8 @@ describe('installHook()', function () {
 
     it('can install a hook with defaults as an array', function (done) {
 
-        Utils.installHook('pre-commit', ['lint', 'test'], Path.join(internals.fixturePath, 'project2'));
+        Utils.installHook('pre-commit', Path.join(internals.fixturePath, 'project2'));
+        Utils.configureHook('pre-commit', ['lint', 'test'], Path.join(internals.fixturePath, 'project2'));
         expect(Fs.existsSync(Path.join(internals.fixturePath, 'project2', '.git', 'hooks', 'pre-commit'))).to.be.true();
         var fixturePackage = JSON.parse(Fs.readFileSync(Path.join(internals.fixturePath, 'project2', 'package.json'), { encoding: 'utf8' }));
         expect(fixturePackage['pre-commit']).to.deep.equal(['lint', 'test']);
@@ -259,11 +268,12 @@ describe('installHook()', function () {
 
     it('won\'t overwrite existing hook settings', function (done) {
 
-        Utils.installHook('pre-commit', 'test', Path.join(internals.fixturePath, 'project2'));
+        Utils.installHook('pre-commit', Path.join(internals.fixturePath, 'project2'));
+        Utils.configureHook('pre-commit', 'test', Path.join(internals.fixturePath, 'project2'));
         expect(Fs.existsSync(Path.join(internals.fixturePath, 'project2', '.git', 'hooks', 'pre-commit'))).to.be.true();
         var fixturePackageOne = JSON.parse(Fs.readFileSync(Path.join(internals.fixturePath, 'project2', 'package.json'), { encoding: 'utf8' }));
         expect(fixturePackageOne['pre-commit']).to.deep.equal(['test']);
-        Utils.installHook('pre-commit', ['lint', 'test'], Path.join(internals.fixturePath, 'project2'));
+        Utils.configureHook('pre-commit', ['lint', 'test'], Path.join(internals.fixturePath, 'project2'));
         var fixturePackageTwo = JSON.parse(Fs.readFileSync(Path.join(internals.fixturePath, 'project2', 'package.json'), { encoding: 'utf8' }));
         expect(fixturePackageTwo['pre-commit']).to.deep.equal(['test']);
         done();

--- a/test/utils.js
+++ b/test/utils.js
@@ -218,22 +218,30 @@ describe('findProjects()', function () {
     after(internals.cleanupFixture);
 });
 
-describe('installHook()', function () {
+describe('installHooks()', function () {
 
     beforeEach(internals.createFixture);
 
     it('can install a hook', function (done) {
 
-        Utils.installHook('pre-commit', Path.join(internals.fixturePath, 'project2'));
+        Utils.installHooks('pre-commit', Path.join(internals.fixturePath, 'project2'));
         expect(Fs.existsSync(Path.join(internals.fixturePath, 'project2', '.git', 'hooks', 'pre-commit'))).to.be.true();
+        done();
+    });
+
+    it('can install multiple hooks at once', function (done) {
+
+        Utils.installHooks(['pre-commit', 'pre-push'], Path.join(internals.fixturePath, 'project2'));
+        expect(Fs.existsSync(Path.join(internals.fixturePath, 'project2', '.git', 'hooks', 'pre-commit'))).to.be.true();
+        expect(Fs.existsSync(Path.join(internals.fixturePath, 'project2', '.git', 'hooks', 'pre-push'))).to.be.true();
         done();
     });
 
     it('backs up an existing hook when installing', function (done) {
 
-        Utils.installHook('pre-commit', Path.join(internals.fixturePath, 'project2'));
+        Utils.installHooks('pre-commit', Path.join(internals.fixturePath, 'project2'));
         expect(Fs.existsSync(Path.join(internals.fixturePath, 'project2', '.git', 'hooks', 'pre-commit'))).to.be.true();
-        Utils.installHook('pre-commit', Path.join(internals.fixturePath, 'project2'));
+        Utils.installHooks('pre-commit', Path.join(internals.fixturePath, 'project2'));
         expect(Fs.existsSync(Path.join(internals.fixturePath, 'project2', '.git', 'hooks', 'pre-commit'))).to.be.true();
         expect(Fs.existsSync(Path.join(internals.fixturePath, 'project2', '.git', 'hooks', 'pre-commit.backup'))).to.be.true();
         done();
@@ -248,7 +256,7 @@ describe('configureHook()', function () {
 
     it('can install a hook with defaults as a string', function (done) {
 
-        Utils.installHook('pre-commit', Path.join(internals.fixturePath, 'project2'));
+        Utils.installHooks('pre-commit', Path.join(internals.fixturePath, 'project2'));
         Utils.configureHook('pre-commit', 'test', Path.join(internals.fixturePath, 'project2'));
         expect(Fs.existsSync(Path.join(internals.fixturePath, 'project2', '.git', 'hooks', 'pre-commit'))).to.be.true();
         var fixturePackage = JSON.parse(Fs.readFileSync(Path.join(internals.fixturePath, 'project2', 'package.json'), { encoding: 'utf8' }));
@@ -258,7 +266,7 @@ describe('configureHook()', function () {
 
     it('can install a hook with defaults as an array', function (done) {
 
-        Utils.installHook('pre-commit', Path.join(internals.fixturePath, 'project2'));
+        Utils.installHooks('pre-commit', Path.join(internals.fixturePath, 'project2'));
         Utils.configureHook('pre-commit', ['lint', 'test'], Path.join(internals.fixturePath, 'project2'));
         expect(Fs.existsSync(Path.join(internals.fixturePath, 'project2', '.git', 'hooks', 'pre-commit'))).to.be.true();
         var fixturePackage = JSON.parse(Fs.readFileSync(Path.join(internals.fixturePath, 'project2', 'package.json'), { encoding: 'utf8' }));
@@ -268,7 +276,7 @@ describe('configureHook()', function () {
 
     it('won\'t overwrite existing hook settings', function (done) {
 
-        Utils.installHook('pre-commit', Path.join(internals.fixturePath, 'project2'));
+        Utils.installHooks('pre-commit', Path.join(internals.fixturePath, 'project2'));
         Utils.configureHook('pre-commit', 'test', Path.join(internals.fixturePath, 'project2'));
         expect(Fs.existsSync(Path.join(internals.fixturePath, 'project2', '.git', 'hooks', 'pre-commit'))).to.be.true();
         var fixturePackageOne = JSON.parse(Fs.readFileSync(Path.join(internals.fixturePath, 'project2', 'package.json'), { encoding: 'utf8' }));

--- a/test/utils.js
+++ b/test/utils.js
@@ -164,7 +164,7 @@ describe('findGitRoot()', function () {
         ChildProcess.exec('node -e \'var path = require("path"); var utils = require("./lib/utils"); utils.findGitRoot(path.resolve(__dirname, "..", ".."));\'', function (err, stdout, stderr) {
 
             expect(err).to.not.exist();
-            expect(stderr).to.equal('WARNING: Unable to find a .git folder for this project, installation aborted.\n');
+            expect(stderr).to.equal('WARNING: Unable to find a .git directory for this project, installation aborted.\n');
             done();
         });
     });

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,3 +1,4 @@
+var ChildProcess = require('child_process');
 var Utils = require('../lib/utils');
 var Fs = require('fs');
 var Path = require('path');
@@ -158,13 +159,14 @@ describe('findGitRoot()', function () {
         done();
     });
 
-    it('can return an error when no git root exists', function (done) {
+    it('logs an error and exits cleanly when no git root is found', function (done) {
 
-        expect(function () {
+        ChildProcess.exec('node -e \'var path = require("path"); var utils = require("./lib/utils"); utils.findGitRoot(path.resolve(__dirname, "..", ".."));\'', function (err, stdout, stderr) {
 
-            Utils.findGitRoot(Path.resolve(__dirname, '..', '..'));
-        }).to.throw('Unable to find a .git folder for this project');
-        done();
+            expect(err).to.not.exist();
+            expect(stderr).to.equal('WARNING: Unable to find a .git folder for this project, installation aborted.\n');
+            done();
+        });
     });
 });
 
@@ -188,12 +190,12 @@ describe('findProjectRoot()', function () {
 
     it('can return an error when no project is found', function (done) {
 
-        var root = Path.resolve(__dirname, '..', '..');
-        expect(function () {
+        ChildProcess.exec('node -e \'var path = require("path"); var utils = require("./lib/utils"); utils.findProjectRoot(path.resolve(__dirname, "..", ".."));\'', function (err, stdout, stderr) {
 
-            Utils.findProjectRoot(root);
-        }).to.throw('Unable to find a package.json for this project');
-        done();
+            expect(err).to.not.exist();
+            expect(stderr).to.equal('WARNING: Unable to find a package.json for this project, installation aborted.\n');
+            done();
+        });
     });
 
     after(internals.cleanupFixture);


### PR DESCRIPTION
This rearranges things to allow removal of the .validate.json concept. It's been confusing, and also the extra file is ugly, so it's gone now. Instead we have helper methods that will add configuration to a package.json file directly, but only if configuration does not already exist.

This change also allows git-validate to be used by itself, as it will create the pre-commit and pre-push hooks by default. Additional hooks can still be created by other packages.