### PR TITLE
Fix installHooks sometimes failing when .git/hooks directory is missing

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -231,12 +231,10 @@ exports.installHooks = function (hooks, root) {
 
     for (var i = 0, il = hooks.length; i < il; ++i) {
         var hook = hooks[i];
-        var destDir = Path.join(gitRoot, '.git', 'hooks');
-        var dest = Path.join(destDir, hook);
-        var source = Path.resolve(__dirname, '..', 'bin', 'validate.sh');
+        var dest = Path.join(hookRoot, hook);
 
-        if (!exports.isDir(destDir)) {
-            internals.mkdir(destDir);
+        if (!exports.isDir(hookRoot)) {
+            internals.mkdir(hookRoot);
         }
 
         if (Fs.existsSync(dest)) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -231,7 +231,13 @@ exports.installHooks = function (hooks, root) {
 
     for (var i = 0, il = hooks.length; i < il; ++i) {
         var hook = hooks[i];
-        var dest = Path.join(hookRoot, hook);
+        var destDir = Path.join(gitRoot, '.git', 'hooks');
+        var dest = Path.join(destDir, hook);
+        var source = Path.resolve(__dirname, '..', 'bin', 'validate.sh');
+
+        if (!exports.isDir(destDir)) {
+            internals.mkdir(destDir);
+        }
 
         if (Fs.existsSync(dest)) {
             Fs.renameSync(dest, dest + '.backup');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -229,13 +229,13 @@ exports.installHooks = function (hooks, root) {
     var hookRoot = Path.join(gitRoot, '.git', 'hooks');
     var source = Path.resolve(__dirname, '..', 'bin', 'validate.sh');
 
+    if (!exports.isDir(hookRoot)) {
+        internals.mkdir(hookRoot);
+    }
+
     for (var i = 0, il = hooks.length; i < il; ++i) {
         var hook = hooks[i];
         var dest = Path.join(hookRoot, hook);
-
-        if (!exports.isDir(hookRoot)) {
-            internals.mkdir(hookRoot);
-        }
 
         if (Fs.existsSync(dest)) {
             Fs.renameSync(dest, dest + '.backup');


### PR DESCRIPTION
On some cases git checkout might not contain .git/hooks directory. This pull request makes a check against the `hookRoot` and creates the directory if it’s missing.