### PR TITLE
Make file copy synchronous.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -107,10 +107,14 @@ internals.copyFile = function (source, target, options) {
         return new Error(target + ' already exists');
     }
 
-    var sourceStream = Fs.createReadStream(source);
-    var targetStream = Fs.createWriteStream(target, { flag: 'w', mode: mode });
+    var sourceContent = '';
+    try {
+        sourceContent = Fs.readFileSync(source);
+    } catch (e) {
+        /* no source to copy */
+    }
 
-    sourceStream.pipe(targetStream);
+    Fs.writeFileSync(target, sourceContent, { flag: 'w', mode: mode });
 };
 
 


### PR DESCRIPTION
*Background:*
There is an issue with using read/write streams. Not sure if it’s intentional, but write stream ends can be delayed. Which means that after file is copied they might not actually be available yet (stream is still open and write not ended).

*Solution:*
One quick solution is to use readFileSync and writeFileSync and force the copy to be synchronous. Behaviour is 100% the same (when source file does not exist, empty file is still created).

*Possible solution for next versions:*
Perhaps this can be done asynchronously as well, with a callback written on `targetStream.on('end', cb)`, but copyFile is used more deeply and requires a bit more work (implement callbacks to copy directory, copy file methods).