### PR TITLE
Update validate.sh

### DIFF
--- a/bin/validate.sh
+++ b/bin/validate.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+PATH=$PATH:/usr/local/bin:/usr/local/sbin
 
 # This section copied from github.com/dominictarr/JSON.sh and simplified a bit
 ##############################################################################


### PR DESCRIPTION
In osx El Capitan environment variables and paths are lost when starting git from GUI applications. For example github own GUI client can ONLY access node with full path. Just "node" will not resolve even if you have it in $PATH. 

This line would solve this issue