### PR TITLE
fix windows execution, closes nfl/precommit-hook#67

### DIFF
--- a/bin/validate.sh
+++ b/bin/validate.sh
@@ -287,7 +287,12 @@ check_project() {
     fi
 
     pushd "$dir" >/dev/null
-    local branch; branch=$(env -i git rev-parse --abbrev-ref HEAD 2>&1)
+    local branch;
+    if [[ "$OSTYPE" -eq "cygwin" || "$OSTYPE" -eq "msys" || "$OSTYPE" -eq "win32" ]]; then
+      branch=$(git rev-parse --abbrev-ref HEAD 2>&1)
+    else
+      branch=$(env -i git rev-parse --abbrev-ref HEAD 2>&1)
+    fi
     if [[ $? -ne 0 ]]; then
         popd >/dev/null
         return 0
@@ -319,7 +324,12 @@ run_hook() {
     fi
 
     local hook_cmd=$(basename $0)
-    local git_root; git_root=$(env -i git rev-parse --show-toplevel)
+    local git_root;
+    if [[ "$OSTYPE" -eq "cygwin" || "$OSTYPE" -eq "msys" || "$OSTYPE" -eq "win32" ]]; then
+      git_root=$(git rev-parse --show-toplevel)
+    else
+      git_root=$(env -i git rev-parse --show-toplevel)
+    fi
     if [[ $? -ne 0 ]]; then
         echo "this does not look like a git repository.. exiting"
         exit 0


### PR DESCRIPTION
Sorry, my bash is near non-existent, but google searching helped me patch things up for windows. In regards to the rules, this was my reference point http://stackoverflow.com/questions/394230/detect-the-os-from-a-bash-script, and I can confirm that this runs fine for Windows.

This is to fix https://github.com/nlf/precommit-hook/issues/67