### PR TITLE
fix: make sure we do not automatically overwrite, but make it a flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,29 @@ would write
 }
 ```
 
-to your package.json, but *only* if the `"pre-commit"` key was not already set.
+to your package.json, but *only* if the `"pre-commit"` key was not already set, or you specify so explicitly:
+
+```javascript
+{
+  "pre-commit": ["test"]
+}
+```
+
+with:
+
+```javascript
+var overwrite = true;
+Validate.configureHook('pre-commit', ['lint', 'test'], overwrite);
+```
+
+would change package.json to:
+
+```javascript
+{
+  "pre-commit": ["lint", "test"]
+}
+```
+
 
 ### `installScript`
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -43,22 +43,6 @@ internals.mkdir = function (path) {
 };
 
 
-internals.arrayUnique = function (array) {
-
-    var a = array.concat();
-
-    for (var i = 0; i < a.length; ++i) {
-        for (var j = i + 1; j < a.length; ++j) {
-            if (a[i] === a[j]) {
-                a.splice(j--, 1);
-            }
-        }
-    }
-
-    return a;
-}
-
-
 // Expands source and target to absolute paths, then calls internals.copy
 exports.copy = function (source, target, options) {
 
@@ -267,15 +251,15 @@ exports.installHooks = function (hooks, root) {
 
 // Provide a default configuration for a git hook as specified by `hook`.
 // For example, Validate.configureHook('pre-commit', ['test', 'lint']);
-exports.configureHook = function (hook, defaults, root) {
+exports.configureHook = function (hook, defaults, overwrite, root) {
 
     var packagePath = Path.join(exports.findProjectRoot(root), 'package.json');
     var package = JSON.parse(Fs.readFileSync(packagePath, { encoding: 'utf8' }));
-    var existingHookValues = package[hook] || [];
-    var newHookValues = Array.isArray(defaults) ? defaults : [defaults];
 
-    package[hook] = internals.arrayUnique(existingHookValues.concat(newHookValues));
-    Fs.writeFileSync(packagePath, JSON.stringify(package, null, 2), { encoding: 'utf8' });
+    if (!package.hasOwnProperty(hook) || overwrite) {
+        package[hook] = Array.isArray(defaults) ? defaults : [defaults];
+        Fs.writeFileSync(packagePath, JSON.stringify(package, null, 2), { encoding: 'utf8' });
+    }
 };
 
 // Configure a default script by name and content

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "the extensible core of precommit-hook",
   "main": "index.js",
   "scripts": {
-    "test": "lab -L -a code -t 100",
+    "test": "lab -L --leaks -a code -t 100",
     "install": "node bin/install"
   },
   "repository": {


### PR DESCRIPTION
This adds a flag to the API that allows us to specify when we want the package.json to be altered explicitly.

fixes #53 