### PR TITLE
Remove old hook if it's a broken symlink

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -243,6 +243,11 @@ exports.installHooks = function (hooks, root) {
 
         if (Fs.existsSync(dest)) {
             Fs.renameSync(dest, dest + '.backup');
+        } else {
+          // There is no harm in removing a non-existant file.
+          // It could also be a broken symlink, which is also fine to be
+          // removed. If it wasn't, writing the new hook would fail.
+          Fs.unlinkSync(dest)
         }
 
         Fs.writeFileSync(dest, Fs.readFileSync(source), { mode: 511 });


### PR DESCRIPTION
If the current hook is a broken symlink, remove it before installing
the hook. If it wouldn't be removed, the installation would fail.

A case where this could happen is, when you switch from one pre-push
manager to another. Steps to reproduce:

    mkdir pre-push-validate
    cd pre-push-validate
    git init
    npm install pre-push
    rm -Rf node_modules
    npm install git-validate