### PR TITLE
Fix failing `unlinkSync()` on non-existing files

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -246,8 +246,14 @@ exports.installHooks = function (hooks, root) {
         } else {
           // There is no harm in removing a non-existant file.
           // It could also be a broken symlink, which is also fine to be
-          // removed. If it wasn't, writing the new hook would fail.
-          Fs.unlinkSync(dest)
+          // removed. If it wasn't removed, writing the new hook would fail.
+          try {
+            Fs.unlinkSync(dest)
+          } catch (err) {
+            if (err.code !== 'ENOENT') {
+              throw err;
+            }
+          }
         }
 
         Fs.writeFileSync(dest, Fs.readFileSync(source), { mode: 511 });


### PR DESCRIPTION
I've tested it with the steps outlined in #67 as well as a fresh installation where there are no hooks yet. Sorry for the inconvenience. 